### PR TITLE
use "rbenv root" to determine a path to available ruby versions

### DIFF
--- a/lib/wwtd/ruby.rb
+++ b/lib/wwtd/ruby.rb
@@ -18,7 +18,7 @@ module WWTD
           if ruby_root = ENV["RUBY_ROOT"] # chruby or RUBY_ROOT set
             switch_via_env(File.dirname(ruby_root), version)
           elsif rbenv_executable
-            rubies_root = cache_command("which rbenv").sub(%r{/(\.?rbenv)/.*}, "/\\1") + "/versions"
+            rubies_root = cache_command("rbenv root") + "/versions"
             switch_via_env(rubies_root, version)
           end
         end


### PR DESCRIPTION
It fixes https://github.com/grosser/wwtd/issues/8.

`rbenv root` is used (instead of `which rbenv`) to determine a path to the ruby version.

From rbenv documentation: "rbenv root command prints the value of $RBENV_ROOT, or the default root directory if it's unset."

``` shell
$ rbenv root
/Users/lukkry/.rbenv

$ ls `rbenv root`/versions
1.9.3-p392  1.9.3-p448  2.0.0-p247

$ rbenv versions
  system
  1.9.3-p392
  1.9.3-p448
* 2.0.0-p247 (set by /Users/lukkry/projects/zendesk/zendesk_voice_core/.ruby-version)
```
