### PR TITLE
cast ruby version to string when creating a path to a lock file

### DIFF
--- a/lib/wwtd/run.rb
+++ b/lib/wwtd/run.rb
@@ -25,7 +25,7 @@ module WWTD
 
     def success?
       if wants_bundle?
-        flock File.join(lock, config["rvm"] || "rvm") do
+        flock File.join(lock, (config["rvm"] || "rvm").to_s) do
           default_bundler_args = "--deployment --path #{Dir.pwd}/vendor/bundle" if committed?("#{gemfile || DEFAULT_GEMFILE}.lock")
           bundle_command = "#{switch}bundle install #{config["bundler_args"] || default_bundler_args}"
           return false unless sh(env, "#{bundle_command.strip} --quiet")

--- a/spec/wwtd_spec.rb
+++ b/spec/wwtd_spec.rb
@@ -79,6 +79,13 @@ describe WWTD do
       wwtd("").should include "bundle install --no-color"
     end
 
+    it "casts ruby version to string when creating a path to a lock file" do
+      write_default_gemfile
+      write "Rakefile", "task(:default) { puts %Q{RUBY: \#{RUBY_VERSION}} }"
+      write ".travis.yml", "rvm: 2.0"
+      wwtd("").should include "RUBY: 2.0.0"
+    end
+
     it "runs with given rvm version" do
       other = (RUBY_VERSION == "1.9.3" ? "2.0.0" : "1.9.3")
       write ".travis.yml", "rvm: #{other}"


### PR DESCRIPTION
It fixes https://github.com/grosser/wwtd/issues/10

``` shell
irb(main):006:0> yaml = YAML.load("rvm: 2.0")
=> {"rvm"=>2.0}
irb(main):008:0> yaml["rvm"].class
=> Float
```
