### PR TITLE
ruby-install prepends directories with 'ruby-'

### DIFF
--- a/lib/wwtd/ruby.rb
+++ b/lib/wwtd/ruby.rb
@@ -55,7 +55,9 @@ module WWTD
       end
 
       def ruby_root(root, version)
-        Dir.glob("#{root}/*").detect { |p| File.basename(p).start_with?(version) }
+        Dir.glob("#{root}/*").detect do |p|
+          File.basename(p).sub(/^ruby-/,"").start_with?(version)
+        end
       end
 
       def cache(key)


### PR DESCRIPTION
@grosser this should fix one of the issues I was seeing this afternoon
