### PR TITLE
support travis's travis.yml matrix include key

### DIFF
--- a/lib/wwtd.rb
+++ b/lib/wwtd.rb
@@ -63,8 +63,12 @@ module WWTD
         matrix = Array(values).map { |value| matrix.map { |c| c.merge(multiplier => value) } }.flatten
       end
 
-      if config["matrix"] && config["matrix"]["exclude"]
-        matrix -= config.delete("matrix").delete("exclude")
+      matrix_config = config.delete("matrix")
+      if matrix_config && matrix_config["exclude"]
+        matrix -= matrix_config["exclude"]
+      end
+      if matrix_config && matrix_config["include"]
+        matrix += matrix_config["include"]
       end
       matrix.map! { |c| config.merge(c) }
     end

--- a/spec/wwtd_spec.rb
+++ b/spec/wwtd_spec.rb
@@ -350,19 +350,23 @@ describe WWTD do
       ]
     end
 
-    it "excludes with" do
+    it "excludes and includes" do
       call(
         "gemfile" => ["Gemfile1", "Gemfile2"],
         "rvm" => ["a", "b"],
         "matrix" => {
           "exclude" => [
             {"gemfile" => "Gemfile1", "rvm" => "b"}
-          ]
+          ],
+          "include" => [
+            {"gemfile" => "Gemfile1", "rvm" => "c"}
+          ],
         }
       ).should == [
         {"rvm"=>"a", "gemfile"=>"Gemfile1"},
         {"rvm"=>"a", "gemfile"=>"Gemfile2"},
         {"rvm"=>"b", "gemfile"=>"Gemfile2"},
+        {"rvm"=>"c", "gemfile"=>"Gemfile1"},
       ]
     end
   end


### PR DESCRIPTION
Travis supports an `include` key in the matrix, as well as an `exclude` key, so this patch enables that support.

http://docs.travis-ci.com/user/build-configuration/#The-Build-Matrix
