### PR TITLE
Switch ruby for every command in `script` section

### DIFF
--- a/lib/wwtd/run.rb
+++ b/lib/wwtd/run.rb
@@ -23,8 +23,8 @@ module WWTD
     def env_and_command
       default_command = (wants_bundle? ? "bundle exec rake" : "rake")
       command = config["script"] || default_command
-      command = command.join(" && ") if Array === command
-      command = "#{switch}#{command}"
+      command = [command] unless Array === command
+      command = command.map { |cmd| "#{switch}#{cmd}" }.join(" && ")
 
       [env, command]
     end

--- a/spec/wwtd_spec.rb
+++ b/spec/wwtd_spec.rb
@@ -116,6 +116,28 @@ describe WWTD do
         result.should include "222\n"
         result.should_not include "111\n"
       end
+
+      it "properly switches versions for every command in the array" do
+        write "Rakefile", <<-EOF
+          task(:foo){ puts "Foo in \#{RUBY_VERSION}" }
+          task(:bar){ puts "Bar in \#{RUBY_VERSION}" }
+        EOF
+
+        write ".travis.yml", <<-EOF
+          script:
+            - rake foo
+            - rake bar
+          rvm:
+            - #{available_ruby_versions[0]}
+            - #{available_ruby_versions[1]}
+        EOF
+
+        result = wwtd("")
+        result.should include("Foo in #{available_ruby_versions[1]}\n")
+        result.should include("Foo in #{available_ruby_versions[0]}\n")
+        result.should include("Bar in #{available_ruby_versions[1]}\n")
+        result.should include("Bar in #{available_ruby_versions[0]}\n")
+      end
     end
 
     it "bundles if there is a Gemfile" do


### PR DESCRIPTION
Currently, if a list of commands is specified in the `script` section,
only the first command is run in the expected Ruby and the rest are run
without switching.