### PR TITLE
Allow build to be specified via matrix.include (fixes #28)

### DIFF
--- a/lib/wwtd.rb
+++ b/lib/wwtd.rb
@@ -108,7 +108,11 @@ module WWTD
           matrix -= exclude
         end
         if include = matrix_config["include"]
-          matrix += include
+          if matrix == [{}]
+            matrix = include
+          else
+            matrix += include
+          end
         end
       end
       matrix.map! { |c| config.merge(c) }

--- a/spec/wwtd_spec.rb
+++ b/spec/wwtd_spec.rb
@@ -484,6 +484,20 @@ describe WWTD do
       ]
     end
 
+    it "builds from include" do
+      call(
+        "matrix" => {
+          "include" => [
+            {"gemfile" => "Gemfile1", "rvm" => "aa"},
+            {"gemfile" => "Gemfile2", "rvm" => "bb"},
+          ],
+        }
+      ).should == [
+        {"rvm"=>"aa", "gemfile"=>"Gemfile1"},
+        {"rvm"=>"bb", "gemfile"=>"Gemfile2"},
+      ]
+    end
+
     it "excludes and includes" do
       call(
         "gemfile" => ["Gemfile1", "Gemfile2"],


### PR DESCRIPTION
This allows you to specify the exact builds you want to run using `matrix:` / `include:`, without getting an extra 'default' build tacked on to the start.