### PR TITLE
don't overwrite already existing env vars

### DIFF
--- a/lib/wwtd.rb
+++ b/lib/wwtd.rb
@@ -74,9 +74,16 @@ module WWTD
 
     private
 
+    def filter_env(env)
+      env.reject do |k, _v|
+        ENV.key?(k)
+      end
+    end
+
     # internal api
     def sh(env, cmd=nil)
       cmd, env = env, {} unless cmd
+      env = filter_env(env)
       env = escaped_env(env)
       puts cmd
       system("#{env}#{cmd}")


### PR DESCRIPTION
this is helpful if your local env is different than real travis

for example, in real travis you have TEST_DB_USERNAME=postgres
in your travis.yml, but locally you have TEST_DB_USERNAME=cody
since you don't want (or have) a postgres superuser named postgres