### PR TITLE
change invocations of deprecated Bundler.with_clean_env

### DIFF
--- a/lib/wwtd.rb
+++ b/lib/wwtd.rb
@@ -39,7 +39,7 @@ module WWTD
 
     def run(matrix, options, &block)
       with_clean_dot_bundle do
-        with_clean_env do
+        with_unbundled_env do
           Dir.mktmpdir do |lock|
             in_multiple_threads(matrix.each_with_index, options[:parallel]) do |config, i|
               # set env as parallel_tests does to reuse existing infrastructure
@@ -136,9 +136,9 @@ module WWTD
       cell.values_at(*exclude.keys) == exclude.values
     end
 
-    def with_clean_env(&block)
+    def with_unbundled_env(&block)
       if defined?(Bundler)
-        Bundler.with_clean_env(&block)
+        Bundler.with_unbundled_env(&block)
       else
         yield
       end

--- a/spec/wwtd_spec.rb
+++ b/spec/wwtd_spec.rb
@@ -16,7 +16,7 @@ describe WWTD do
     end
 
     def bundle(extra="")
-      Bundler.with_clean_env { sh "bundle #{extra}" }
+      Bundler.with_unbundled_env { sh "bundle #{extra}" }
     end
 
     def write_default_gemfile(rake_version="0.9.2.2")


### PR DESCRIPTION
fixes warning:
[DEPRECATED] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env`

I'm not actually sure if this should call `with_unbundled_env` or `with_original_env` though. I'll switch to `with_original_env` if somebody knows that is better.